### PR TITLE
Add showtext pkg to imports in description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Imports:
     dsvizopts,
     ggtext,
     gridExtra,
-    treemapify
+    treemapify,
+    showtext
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: no


### PR DESCRIPTION
Adding missing `showtext` package to `Imports` in `DESCRIPTION` file.